### PR TITLE
Fix in formio.html for grids within grids

### DIFF
--- a/camunda-formio-plugin/src/main/resources/static/formio.html
+++ b/camunda-formio-plugin/src/main/resources/static/formio.html
@@ -89,7 +89,8 @@
             FormioUtils.eachComponent(
               form.components,
               function (c) {
-                createVariable(variableManager, c.component.key, "string");
+                let key = c.component !== undefined ? c.component.key : c.key;
+                createVariable(variableManager, key, "string");
               },
               true,
             );
@@ -120,7 +121,8 @@
               }
 
               FormioUtils.eachComponent(form.components, function (c) {
-                const value = variableManager.variableValue(c.component.key);
+                let key = c.component !== undefined ? c.component.key : c.key;
+                const value = variableManager.variableValue(key);
                 if (value !== undefined && value !== null)
                   submission.data[c.component.key] = value;
               });


### PR DESCRIPTION
I've found an issue when dealing with grids within grids with the original "formio.html" source file.

This fix seems to have corrected that problem, by correctly handling the key in those specific situations.